### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Send requests to OpenAI, MistralAI, Anthropic, xAI, or Google AI using MCP proto
 
 Both STDIO and SSE transport mechanisms supported via arguments.
 
+<a href="https://glama.ai/mcp/servers/ub2u8wtbbv"><img width="380" height="200" src="https://glama.ai/mcp/servers/ub2u8wtbbv/badge" alt="unichat-ts-mcp-server MCP server" /></a>
+
 ### Tools
 
 The server implements one tool:


### PR DESCRIPTION
This PR adds a badge for the unichat-ts-mcp-server server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/ub2u8wtbbv"><img width="380" height="200" src="https://glama.ai/mcp/servers/ub2u8wtbbv/badge" alt="unichat-ts-mcp-server MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.